### PR TITLE
Add AuthRefreshToken entity and migration

### DIFF
--- a/BackendAPI/API/APIs/Migrations/Auth/20251007035452_AddRefreshtokenTable.Designer.cs
+++ b/BackendAPI/API/APIs/Migrations/Auth/20251007035452_AddRefreshtokenTable.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Auth.Data.Context;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace APIs.Migrations.Auth
 {
     [DbContext(typeof(AuthApplicationDbContext))]
-    partial class AuthApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20251007035452_AddRefreshtokenTable")]
+    partial class AddRefreshtokenTable
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/BackendAPI/API/APIs/Migrations/Auth/20251007035452_AddRefreshtokenTable.cs
+++ b/BackendAPI/API/APIs/Migrations/Auth/20251007035452_AddRefreshtokenTable.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+#nullable disable
+
+namespace APIs.Migrations.Auth
+{
+    /// <inheritdoc />
+    public partial class AddRefreshtokenTable : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "AuthRefreshToken",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    UserId = table.Column<Guid>(type: "uuid", nullable: false),
+                    TokenHash = table.Column<string>(type: "text", nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    ExpiresAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    RevokedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    RevokedReason = table.Column<string>(type: "text", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_AuthRefreshToken", x => x.Id);
+                });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "AuthRefreshToken");
+        }
+    }
+}

--- a/BackendAPI/Modules/Auth/Data/Context/AuthApplicationDbContext.cs
+++ b/BackendAPI/Modules/Auth/Data/Context/AuthApplicationDbContext.cs
@@ -2,22 +2,24 @@
 namespace Auth.Data.Context;
 public class AuthApplicationDbContext : DbContext
 {
-    public AuthApplicationDbContext(DbContextOptions<AuthApplicationDbContext> options) : base(options)
-    {
-    }
+	public AuthApplicationDbContext(DbContextOptions<AuthApplicationDbContext> options) : base(options)
+	{
+	}
 
-    public DbSet<Authusers> AuthUsers { get; set; }
+	public DbSet<Authusers> AuthUsers { get; set; }
 
-    public DbSet<AuthApplication> AuthApplications { get; set; }
+	public DbSet<AuthApplication> AuthApplications { get; set; }
 
-    public DbSet<AuthRole> AuthRoles { get; set; }
+	public DbSet<AuthRole> AuthRoles { get; set; }
 
-    public DbSet<AuthUserAppRole> AuthUserAppRoles { get; set; }
+	public DbSet<AuthUserAppRole> AuthUserAppRoles { get; set; }
 
-    protected override void OnModelCreating(ModelBuilder modelBuilder)
-    {
-        modelBuilder.ApplyConfigurationsFromAssembly(typeof(AuthApplicationDbContext).Assembly);
-        base.OnModelCreating(modelBuilder);
-    }
+	public DbSet<AuthRefreshToken> AuthRefreshToken { get; set; }
+
+	protected override void OnModelCreating(ModelBuilder modelBuilder)
+	{
+		modelBuilder.ApplyConfigurationsFromAssembly(typeof(AuthApplicationDbContext).Assembly);
+		base.OnModelCreating(modelBuilder);
+	}
 
 }

--- a/BackendAPI/Modules/Auth/Data/Entities/AuthRefreshToken.cs
+++ b/BackendAPI/Modules/Auth/Data/Entities/AuthRefreshToken.cs
@@ -1,0 +1,12 @@
+﻿namespace Auth.Data.Entities;
+
+public class AuthRefreshToken
+{
+	public int Id { get; set; }
+	public Guid UserId { get; set; }
+	public string TokenHash { get; set; }
+	public DateTime CreatedAt { get; set; }
+	public DateTime ExpiresAt { get; set; }
+	public DateTime? RevokedAt { get; set; }
+	public string? RevokedReason { get; set; }
+}

--- a/BackendAPI/Modules/Auth/Data/EntityConfiguration/AuthRefreshTokenConfiguration.cs
+++ b/BackendAPI/Modules/Auth/Data/EntityConfiguration/AuthRefreshTokenConfiguration.cs
@@ -1,0 +1,10 @@
+﻿
+namespace Auth.Data.EntityConfiguration;
+
+internal class AuthRefreshTokenConfiguration : IEntityTypeConfiguration<AuthRefreshToken>
+{
+	public void Configure(EntityTypeBuilder<AuthRefreshToken> builder)
+	{
+		builder.HasKey(e => e.Id);
+	}
+}


### PR DESCRIPTION
Introduce AuthRefreshToken entity to manage refresh tokens for user sessions. Add DbSet<AuthRefreshToken> in AuthApplicationDbContext and update OnModelCreating method. Create migration for new table and configuration class. Update model snapshot to reflect changes.